### PR TITLE
Fix parse failure when using digest auth

### DIFF
--- a/internal/wsman/digest.go
+++ b/internal/wsman/digest.go
@@ -105,7 +105,7 @@ func (c *challenge) parseChallenge(input string) error {
 		return fmt.Errorf("challenge is bad, missing prefix: %s", input)
 	}
 	s = strings.Trim(s[7:], ws)
-	sl := strings.Split(s, ",")
+	sl := strings.Split(s, "\",")
 	c.Algorithm = "MD5"
 	var r []string
 	for i := range sl {
@@ -124,8 +124,10 @@ func (c *challenge) parseChallenge(input string) error {
 		case "algorithm":
 			c.Algorithm = strings.Trim(r[1], qs)
 		case "qop":
-			// TODO(gavaletz) should be an array of strings?
-			c.Qop = strings.Trim(r[1], qs)
+			// currently only "auth" is used, and other QoP parameters
+			// are not implemented, so only use "auth" for now
+			// TODO handle multiple params like "auth,auth-int"
+			c.Qop = "auth"
 		default:
 			return fmt.Errorf("challenge is bad, unexpected token: %s", sl)
 		}


### PR DESCRIPTION
Newer versions of Intel AMT use digest auth with different [parameters](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#qop) depending on what the server supports. Parsing currently fails when parameters other than "auth" are provided. Running the iamt [example](https://github.com/jacobweinstock/iamt/blob/main/example/main.go) I get the following output:

```
~/src/iamt/example$ ./example 
panic: failed to parse auth header challenge is bad, unexpected token: [realm="Digest:D15CF4BF35F8D0F6CEFD0AA92D4D496A"  nonce="jyTb0E1UAAAAAAAADG/kz8n0/Pb6clW5" stale="false" qop="auth auth-int  auth"]

goroutine 1 [running]:
main.main()
        ~src/iamt/example/main.go:22 +0x272
```

With my changes, I now get a successful result:
```
~/src/iamt/example$ ./example 
Is powered on? true
```

I'm currently using a Minisforum MS-01 with Intel AMT v16 and want to deploy a CAPT cluster.

This PR fixes the parse since, parameters other than "auth" are not supported anyway according to this [comment](https://github.com/jacobweinstock/iamt/blob/d7cdbe67d9eff2504a8517f26d0131600ad25674/internal/wsman/digest.go#L71).