### PR TITLE
fix: handle malformed digest auth headers from Intel NUCs

### DIFF
--- a/internal/wsman/digest.go
+++ b/internal/wsman/digest.go
@@ -11,13 +11,11 @@ import (
 	"strings"
 )
 
-// Package level compiled regular expressions to avoid recompilation on each call.
+// Package level compiled regular expressions to avoid compilation on each call.
 var (
 	// digestFieldRe extracts key="value" pairs from digest auth headers.
-	// Handles both comma-separated and space-separated fields.
-	digestFieldRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
-	// qopSplitRe splits qop values by whitespace or commas.
-	qopSplitRe = regexp.MustCompile(`[\s,]+`)
+	// Handles both comma-separated and space-separated fields, and supports escaped quotes in values.
+	digestFieldRe = regexp.MustCompile(`(\w+)="((?:\\.|[^"\\])*)"`)
 )
 
 type challenge struct {
@@ -153,11 +151,11 @@ func (c *challenge) parseChallenge(input string) error {
 // duplicates and extra whitespace) instead of the standard comma-separated format.
 // If "auth" is not found, returns empty string to fall back to no-qop behavior.
 func normalizeQop(qop string) string {
-	parts := qopSplitRe.Split(qop, -1)
-	for _, p := range parts {
-		if p == "auth" {
-			return "auth"
-		}
+	// Normalize separators and pad with spaces for word boundary check.
+	// This avoids array allocation from splitting.
+	padded := " " + strings.ReplaceAll(qop, ",", " ") + " "
+	if strings.Contains(padded, " auth ") {
+		return "auth"
 	}
 	return ""
 }

--- a/internal/wsman/digest.go
+++ b/internal/wsman/digest.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// Package level compiled regexes to avoid recompilation on each call.
+// Package level compiled regular expressions to avoid recompilation on each call.
 var (
 	// digestFieldRe extracts key="value" pairs from digest auth headers.
 	// Handles both comma-separated and space-separated fields.
@@ -151,6 +151,7 @@ func (c *challenge) parseChallenge(input string) error {
 // normalizeQop handles malformed qop values from some Intel AMT implementations.
 // Some Intel NUCs return qop like "auth auth-int  auth" (space-separated with
 // duplicates and extra whitespace) instead of the standard comma-separated format.
+// If "auth" is not found, returns empty string to fall back to no-qop behavior.
 func normalizeQop(qop string) string {
 	parts := qopSplitRe.Split(qop, -1)
 	for _, p := range parts {
@@ -158,5 +159,5 @@ func normalizeQop(qop string) string {
 			return "auth"
 		}
 	}
-	return qop
+	return ""
 }

--- a/internal/wsman/digest.go
+++ b/internal/wsman/digest.go
@@ -11,6 +11,15 @@ import (
 	"strings"
 )
 
+// Package level compiled regexes to avoid recompilation on each call.
+var (
+	// digestFieldRe extracts key="value" pairs from digest auth headers.
+	// Handles both comma-separated and space-separated fields.
+	digestFieldRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
+	// qopSplitRe splits qop values by whitespace or commas.
+	qopSplitRe = regexp.MustCompile(`[\s,]+`)
+)
+
 type challenge struct {
 	Username   string
 	Password   string
@@ -99,10 +108,10 @@ func (c *challenge) authorize(method, uri string) (string, error) {
 	return fmt.Sprintf("Digest %s", strings.Join(sl, ",")), nil
 }
 
-// origin https://code.google.com/p/mlab-ns2/source/browse/gae/ns/digest/digest.go#90
-// Modified to handle malformed Intel AMT headers:
-// - Space-separated fields instead of comma-separated
-// - Malformed qop values like "auth auth-int  auth"
+// parseChallenge is based on https://code.google.com/p/mlab-ns2/source/browse/gae/ns/digest/digest.go#90
+// but modified to handle malformed Intel AMT headers:
+//   - Space-separated fields instead of comma-separated.
+//   - Malformed qop values like "auth auth-int  auth".
 func (c *challenge) parseChallenge(input string) error {
 	const ws = " \n\r\t"
 	s := strings.Trim(input, ws)
@@ -112,15 +121,10 @@ func (c *challenge) parseChallenge(input string) error {
 	s = strings.Trim(s[7:], ws)
 	c.Algorithm = "MD5"
 
-	// Use regex to extract key="value" pairs
-	// This handles both comma-separated and space-separated fields
-	re := regexp.MustCompile(`(\w+)="([^"]*)"`)
-	matches := re.FindAllStringSubmatch(s, -1)
+	matches := digestFieldRe.FindAllStringSubmatch(s, -1)
 
 	for _, match := range matches {
-		if len(match) != 3 {
-			continue
-		}
+		// match is [fullMatch, key, value] from the regex (\w+)="([^"]*)".
 		key := strings.TrimSpace(match[1])
 		value := match[2]
 
@@ -148,8 +152,7 @@ func (c *challenge) parseChallenge(input string) error {
 // Some Intel NUCs return qop like "auth auth-int  auth" (space-separated with
 // duplicates and extra whitespace) instead of the standard comma-separated format.
 func normalizeQop(qop string) string {
-	re := regexp.MustCompile(`[\s,]+`)
-	parts := re.Split(qop, -1)
+	parts := qopSplitRe.Split(qop, -1)
 	for _, p := range parts {
 		if p == "auth" {
 			return "auth"

--- a/internal/wsman/digest.go
+++ b/internal/wsman/digest.go
@@ -1,3 +1,5 @@
+// Package wsman provides digest authentication for Intel AMT.
+// This is a patched version that handles malformed headers from some Intel NUCs.
 package wsman
 
 import (
@@ -5,6 +7,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -97,38 +100,60 @@ func (c *challenge) authorize(method, uri string) (string, error) {
 }
 
 // origin https://code.google.com/p/mlab-ns2/source/browse/gae/ns/digest/digest.go#90
+// Modified to handle malformed Intel AMT headers:
+// - Space-separated fields instead of comma-separated
+// - Malformed qop values like "auth auth-int  auth"
 func (c *challenge) parseChallenge(input string) error {
 	const ws = " \n\r\t"
-	const qs = `"`
 	s := strings.Trim(input, ws)
 	if !strings.HasPrefix(s, "Digest ") {
 		return fmt.Errorf("challenge is bad, missing prefix: %s", input)
 	}
 	s = strings.Trim(s[7:], ws)
-	sl := strings.Split(s, ",")
 	c.Algorithm = "MD5"
-	var r []string
-	for i := range sl {
-		r = strings.SplitN(sl[i], "=", 2)
-		switch strings.TrimSpace(r[0]) {
+
+	// Use regex to extract key="value" pairs
+	// This handles both comma-separated and space-separated fields
+	re := regexp.MustCompile(`(\w+)="([^"]*)"`)
+	matches := re.FindAllStringSubmatch(s, -1)
+
+	for _, match := range matches {
+		if len(match) != 3 {
+			continue
+		}
+		key := strings.TrimSpace(match[1])
+		value := match[2]
+
+		switch key {
 		case "realm":
-			c.Realm = strings.Trim(r[1], qs)
+			c.Realm = value
 		case "domain":
-			c.Domain = strings.Trim(r[1], qs)
+			c.Domain = value
 		case "nonce":
-			c.Nonce = strings.Trim(r[1], qs)
+			c.Nonce = value
 		case "opaque":
-			c.Opaque = strings.Trim(r[1], qs)
+			c.Opaque = value
 		case "stale":
-			c.Stale = strings.Trim(r[1], qs)
+			c.Stale = value
 		case "algorithm":
-			c.Algorithm = strings.Trim(r[1], qs)
+			c.Algorithm = value
 		case "qop":
-			// TODO(gavaletz) should be an array of strings?
-			c.Qop = strings.Trim(r[1], qs)
-		default:
-			return fmt.Errorf("challenge is bad, unexpected token: %s", sl)
+			c.Qop = normalizeQop(value)
 		}
 	}
 	return nil
+}
+
+// normalizeQop handles malformed qop values from some Intel AMT implementations.
+// Some Intel NUCs return qop like "auth auth-int  auth" (space-separated with
+// duplicates and extra whitespace) instead of the standard comma-separated format.
+func normalizeQop(qop string) string {
+	re := regexp.MustCompile(`[\s,]+`)
+	parts := re.Split(qop, -1)
+	for _, p := range parts {
+		if p == "auth" {
+			return "auth"
+		}
+	}
+	return qop
 }

--- a/internal/wsman/digest.go
+++ b/internal/wsman/digest.go
@@ -122,7 +122,7 @@ func (c *challenge) parseChallenge(input string) error {
 	matches := digestFieldRe.FindAllStringSubmatch(s, -1)
 
 	for _, match := range matches {
-		// match is [fullMatch, key, value] from the regex (\w+)="([^"]*)".
+		// match is [fullMatch, key, value] from the regex (\w+)="((?:\\.|[^"\\])*)", which supports escaped characters in values.
 		key := strings.TrimSpace(match[1])
 		value := match[2]
 

--- a/internal/wsman/digest_test.go
+++ b/internal/wsman/digest_test.go
@@ -1,0 +1,159 @@
+package wsman
+
+import "testing"
+
+func TestParseChallenge(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantRealm string
+		wantNonce string
+		wantQop   string
+		wantAlg   string
+		wantErr   bool
+	}{
+		{
+			name:      "standard comma-separated header",
+			input:     `Digest realm="test@example.com", nonce="abc123", qop="auth", algorithm="MD5"`,
+			wantRealm: "test@example.com",
+			wantNonce: "abc123",
+			wantQop:   "auth",
+			wantAlg:   "MD5",
+		},
+		{
+			name:      "space-separated fields (Intel NUC style)",
+			input:     `Digest realm="Digest:12345678"  nonce="abcdefghij" qop="auth"`,
+			wantRealm: "Digest:12345678",
+			wantNonce: "abcdefghij",
+			wantQop:   "auth",
+			wantAlg:   "MD5",
+		},
+		{
+			name:      "malformed qop with duplicates and extra whitespace",
+			input:     `Digest realm="test" nonce="xyz" qop="auth auth-int  auth"`,
+			wantRealm: "test",
+			wantNonce: "xyz",
+			wantQop:   "auth",
+			wantAlg:   "MD5",
+		},
+		{
+			name:      "qop with only auth-int returns empty",
+			input:     `Digest realm="test" nonce="xyz" qop="auth-int"`,
+			wantRealm: "test",
+			wantNonce: "xyz",
+			wantQop:   "",
+			wantAlg:   "MD5",
+		},
+		{
+			name:      "mixed comma and space separators",
+			input:     `Digest realm="mixed", nonce="123"  qop="auth" algorithm="MD5"`,
+			wantRealm: "mixed",
+			wantNonce: "123",
+			wantQop:   "auth",
+			wantAlg:   "MD5",
+		},
+		{
+			name:    "missing Digest prefix",
+			input:   `Basic realm="test"`,
+			wantErr: true,
+		},
+		{
+			name:      "no qop specified defaults to empty",
+			input:     `Digest realm="test", nonce="abc"`,
+			wantRealm: "test",
+			wantNonce: "abc",
+			wantQop:   "",
+			wantAlg:   "MD5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &challenge{}
+			err := c.parseChallenge(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if c.Realm != tt.wantRealm {
+				t.Errorf("Realm = %q, want %q", c.Realm, tt.wantRealm)
+			}
+			if c.Nonce != tt.wantNonce {
+				t.Errorf("Nonce = %q, want %q", c.Nonce, tt.wantNonce)
+			}
+			if c.Qop != tt.wantQop {
+				t.Errorf("Qop = %q, want %q", c.Qop, tt.wantQop)
+			}
+			if c.Algorithm != tt.wantAlg {
+				t.Errorf("Algorithm = %q, want %q", c.Algorithm, tt.wantAlg)
+			}
+		})
+	}
+}
+
+func TestNormalizeQop(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "standard auth",
+			input: "auth",
+			want:  "auth",
+		},
+		{
+			name:  "auth-int only returns empty",
+			input: "auth-int",
+			want:  "",
+		},
+		{
+			name:  "space-separated with auth",
+			input: "auth auth-int",
+			want:  "auth",
+		},
+		{
+			name:  "malformed with duplicates and extra whitespace",
+			input: "auth auth-int  auth",
+			want:  "auth",
+		},
+		{
+			name:  "comma-separated with auth",
+			input: "auth,auth-int",
+			want:  "auth",
+		},
+		{
+			name:  "auth-int first then auth",
+			input: "auth-int auth",
+			want:  "auth",
+		},
+		{
+			name:  "empty string returns empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "unknown qop returns empty",
+			input: "unknown",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeQop(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeQop(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Uses regex to extract `key="value"` pairs regardless of field separator (comma or space)
- Adds `normalizeQop()` function to extract "auth" from malformed qop values

## Problem

Some Intel NUCs return non-standard WWW-Authenticate headers with:
- Space-separated fields instead of comma-separated
- Malformed qop values like `"auth auth-int  auth"` (with extra whitespace and duplicates)

This causes the current `parseChallenge` function to fail with:
```
challenge is bad, unexpected token: [realm="Digest:..."  nonce="..." qop="auth auth-int  auth"]
```

## Test plan

- [x] Tested with Intel NUC devices via Tinkerbell/Rufio BMC management
- [x] Successfully connects and authenticates with Intel AMT after fix

Fixes #2